### PR TITLE
Add Flask visitor register web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.db
+*.pdf
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.db
 *.pdf
 __pycache__/
+visitors.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Registre de Passage Numérique
+
+Ce projet propose une application web simple permettant de saisir les entrées de visiteurs et d'exporter le registre hebdomadaire au format PDF.
+
+## Installation
+
+1. Installer les dépendances Python:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Lancer le serveur Flask:
+   ```bash
+   python main.py
+   ```
+
+L'application écoute par défaut sur le port `8000`.
+
+## Utilisation
+
+- Rendez-vous sur la page d'accueil pour remplir le formulaire et signer.
+- La page `/export` permet de télécharger le registre de la semaine courante au format PDF.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Registre de Passage Numérique
 
-Ce projet propose une application web simple permettant de saisir les entrées de visiteurs et d'exporter le registre hebdomadaire au format PDF.
+Ce projet propose une application web simple permettant de saisir les entrées de visiteurs. Les données sont stockées dans le fichier `visitors.json` et il est possible d'exporter automatiquement le registre hebdomadaire au format PDF.
 
 ## Installation
 
@@ -14,6 +14,8 @@ Ce projet propose une application web simple permettant de saisir les entrées d
    ```
 
 L'application écoute par défaut sur le port `8000`.
+
+Aucune base de données n'est nécessaire, l'ensemble des enregistrements est conservé dans un fichier JSON côté serveur.
 
 ## Utilisation
 

--- a/main.py
+++ b/main.py
@@ -1,26 +1,23 @@
 from datetime import datetime, date, timedelta
-import base64
 import io
 
 from flask import Flask, render_template, request, redirect, send_file
-from flask_sqlalchemy import SQLAlchemy
+import json
 from fpdf import FPDF
 
 app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///visitors.db'
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+DATA_FILE = "visitors.json"
 
-db = SQLAlchemy(app)
+def load_data() -> list:
+    try:
+        with open(DATA_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return []
 
-class Visitor(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    first_name = db.Column(db.String(100))
-    last_name = db.Column(db.String(100))
-    company = db.Column(db.String(100))
-    reason = db.Column(db.String(200))
-    host = db.Column(db.String(100))
-    signature = db.Column(db.Text)  # base64 data URL
+def save_data(entries: list) -> None:
+    with open(DATA_FILE, "w", encoding="utf-8") as f:
+        json.dump(entries, f, ensure_ascii=False, indent=2)
 
 def start_of_week(dt: date) -> datetime:
     start = dt - timedelta(days=dt.weekday())
@@ -32,16 +29,18 @@ def index():
 
 @app.route('/submit', methods=['POST'])
 def submit():
-    data = Visitor(
-        first_name=request.form.get('first_name'),
-        last_name=request.form.get('last_name'),
-        company=request.form.get('company'),
-        reason=request.form.get('reason'),
-        host=request.form.get('host'),
-        signature=request.form.get('signature')
-    )
-    db.session.add(data)
-    db.session.commit()
+    entries = load_data()
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "first_name": request.form.get("first_name"),
+        "last_name": request.form.get("last_name"),
+        "company": request.form.get("company"),
+        "reason": request.form.get("reason"),
+        "host": request.form.get("host"),
+        "signature": request.form.get("signature")
+    }
+    entries.append(entry)
+    save_data(entries)
     return redirect('/')
 
 @app.route('/export')
@@ -49,22 +48,42 @@ def export_pdf():
     today = date.today()
     start = start_of_week(today)
     end = start + timedelta(days=7)
-    entries = Visitor.query.filter(Visitor.timestamp >= start, Visitor.timestamp < end).all()
+    raw_entries = load_data()
+    entries = []
+    for e in raw_entries:
+        ts = datetime.fromisoformat(e["timestamp"])
+        if start <= ts < end:
+            entries.append({**e, "timestamp": ts})
 
     pdf = FPDF()
     pdf.add_page()
     pdf.set_font('Arial', 'B', 12)
     pdf.cell(0, 10, f"Registre de la semaine du {start.date()} au {end.date()}", ln=True)
 
-    pdf.set_font('Arial', '', 10)
+    headers = ["Date", "Nom", "Prénom", "Entreprise", "Motif", "Hôte"]
+    widths = [30, 30, 30, 40, 40, 30]
+
+    pdf.set_font('Arial', 'B', 10)
+    for h, w in zip(headers, widths):
+        pdf.cell(w, 10, h, border=1)
+    pdf.ln()
+
+    pdf.set_font('Arial', '', 9)
     for e in entries:
-        line = f"{e.timestamp:%Y-%m-%d %H:%M} | {e.first_name} {e.last_name} | {e.company} | {e.reason} | {e.host}"
-        pdf.multi_cell(0, 10, line)
+        values = [
+            e['timestamp'].strftime('%Y-%m-%d %H:%M'),
+            e['last_name'],
+            e['first_name'],
+            e.get('company', ''),
+            e.get('reason', ''),
+            e.get('host', '')
+        ]
+        for v, w in zip(values, widths):
+            pdf.cell(w, 10, str(v), border=1)
+        pdf.ln()
 
     pdf_bytes = pdf.output(dest='S').encode('latin1')
     return send_file(io.BytesIO(pdf_bytes), download_name='registre.pdf', mimetype='application/pdf')
 
 if __name__ == '__main__':
-    with app.app_context():
-        db.create_all()
     app.run(host='0.0.0.0', port=8000)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,70 @@
+from datetime import datetime, date, timedelta
+import base64
+import io
+
+from flask import Flask, render_template, request, redirect, send_file
+from flask_sqlalchemy import SQLAlchemy
+from fpdf import FPDF
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///visitors.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
+
+class Visitor(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    first_name = db.Column(db.String(100))
+    last_name = db.Column(db.String(100))
+    company = db.Column(db.String(100))
+    reason = db.Column(db.String(200))
+    host = db.Column(db.String(100))
+    signature = db.Column(db.Text)  # base64 data URL
+
+def start_of_week(dt: date) -> datetime:
+    start = dt - timedelta(days=dt.weekday())
+    return datetime.combine(start, datetime.min.time())
+
+@app.route('/', methods=['GET'])
+def index():
+    return render_template('index.html')
+
+@app.route('/submit', methods=['POST'])
+def submit():
+    data = Visitor(
+        first_name=request.form.get('first_name'),
+        last_name=request.form.get('last_name'),
+        company=request.form.get('company'),
+        reason=request.form.get('reason'),
+        host=request.form.get('host'),
+        signature=request.form.get('signature')
+    )
+    db.session.add(data)
+    db.session.commit()
+    return redirect('/')
+
+@app.route('/export')
+def export_pdf():
+    today = date.today()
+    start = start_of_week(today)
+    end = start + timedelta(days=7)
+    entries = Visitor.query.filter(Visitor.timestamp >= start, Visitor.timestamp < end).all()
+
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font('Arial', 'B', 12)
+    pdf.cell(0, 10, f"Registre de la semaine du {start.date()} au {end.date()}", ln=True)
+
+    pdf.set_font('Arial', '', 10)
+    for e in entries:
+        line = f"{e.timestamp:%Y-%m-%d %H:%M} | {e.first_name} {e.last_name} | {e.company} | {e.reason} | {e.host}"
+        pdf.multi_cell(0, 10, line)
+
+    pdf_bytes = pdf.output(dest='S').encode('latin1')
+    return send_file(io.BytesIO(pdf_bytes), download_name='registre.pdf', mimetype='application/pdf')
+
+if __name__ == '__main__':
+    with app.app_context():
+        db.create_all()
+    app.run(host='0.0.0.0', port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 flask
-flask_sqlalchemy
 fpdf2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+flask_sqlalchemy
+fpdf2

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="fr">
+<head>
+    <meta charset="utf-8">
+    <title>Registre de Passage</title>
+    <script src="https://cdn.jsdelivr.net/npm/signature_pad@4.0.0/dist/signature_pad.umd.min.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        canvas { border: 1px solid #000; }
+    </style>
+</head>
+<body>
+    <h1>Registre de Passage</h1>
+    <form method="post" action="/submit" onsubmit="prepareSignature()">
+        <label>Prénom: <input type="text" name="first_name" required></label><br>
+        <label>Nom: <input type="text" name="last_name" required></label><br>
+        <label>Entreprise: <input type="text" name="company"></label><br>
+        <label>Motif de la visite: <input type="text" name="reason" required></label><br>
+        <label>Personne visitée: <input type="text" name="host" required></label><br>
+        <p>Signature:</p>
+        <canvas id="sig" width="300" height="150"></canvas><br>
+        <button type="button" onclick="signaturePad.clear()">Effacer</button>
+        <input type="hidden" name="signature" id="signature">
+        <br><br>
+        <button type="submit">Valider</button>
+    </form>
+    <p><a href="/export" target="_blank">Exporter la semaine en PDF</a></p>
+
+<script>
+var canvas = document.getElementById('sig');
+var signaturePad = new SignaturePad(canvas);
+function prepareSignature() {
+    if (!signaturePad.isEmpty()) {
+        document.getElementById('signature').value = signaturePad.toDataURL();
+    }
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create Python Flask app for visitor registry
- store visitor info in SQLite
- generate weekly PDF export
- document setup in README

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_686e5fd207e48331af6968d1c687f04f