### PR TITLE
Fix PDF export alignment and signature

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -47,10 +47,6 @@
             height: 150px;
             border: 1px solid #000;
         }
-        .link {
-            text-align: center;
-            margin-top: 20px;
-        }
     </style>
 </head>
 <body>
@@ -77,9 +73,6 @@
         <input type="hidden" name="signature" id="signature">
         <button type="submit">Valider</button>
     </form>
-    <div class="link">
-        <a href="/admin">Administration</a>
-    </div>
 
 <script>
 var canvas = document.getElementById('sig');


### PR DESCRIPTION
## Summary
- display the PDF title centered
- include visitor signatures in the exported PDF
- increase row height to fit the signature
- remove the admin link from the main form page

## Testing
- `python -m py_compile main.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686e70aad5508331b80de23a48f7c8de