### PR TITLE
Fix output page update

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -20,5 +20,6 @@
 <body>
     <h1>Administration</h1>
     <p><a href="/export" class="button">Exporter la semaine en PDF</a></p>
+    <p><a href="/entries" class="button">Voir les entrées de la semaine</a></p>
 </body>
 </html>

--- a/templates/entries.html
+++ b/templates/entries.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="fr">
+<head>
+    <meta charset="utf-8">
+    <title>Registre hebdomadaire</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+        th { background: #f0f0f0; }
+    </style>
+</head>
+<body>
+    <h1>Registre de la semaine</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>Nom</th>
+                <th>Prénom</th>
+                <th>Entreprise</th>
+                <th>Motif</th>
+                <th>Hôte</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for e in entries %}
+            <tr>
+                <td>{{ e.timestamp.strftime('%Y-%m-%d %H:%M') }}</td>
+                <td>{{ e.last_name }}</td>
+                <td>{{ e.first_name }}</td>
+                <td>{{ e.company }}</td>
+                <td>{{ e.reason }}</td>
+                <td>{{ e.host }}</td>
+            </tr>
+            {% else %}
+            <tr><td colspan="6">Aucune entrée cette semaine.</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- display current week's entries via `/entries`
- reuse weekly entry logic in PDF export
- link to the entries view from the admin page

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686f6c8b85e48331b3fd95299c12b880